### PR TITLE
Feat/runes bridge deployment

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -116,6 +116,23 @@ services:
     networks:
       - bitcoin_network
 
+  utu_auto_claim:
+    container_name: utu_auto_claim
+    # todo for prod: switch to PROD env variable
+    build:
+      context: https://github.com/lfglabs-dev/utu_bridge_auto_claim.git#main
+      dockerfile: Dockerfile
+    volumes:
+      - type: bind
+        source: ./.env
+        target: /app/.env.keys
+    depends_on:
+      utu_api:
+        condition: service_started
+    restart: unless-stopped
+    networks:
+      - bitcoin_network
+
 volumes:
   nginx_secrets:
 

--- a/compose.yml
+++ b/compose.yml
@@ -133,7 +133,33 @@ services:
     networks:
       - bitcoin_network
 
+  etcd:
+    image: docker.io/bitnami/etcd:3.5
+    environment:
+      ALLOW_NONE_AUTHENTICATION: "yes"
+    volumes:
+      - etcd_data:/bitnami/etcd
+
+  utu_bridge_indexer:
+    build:
+      context: https://github.com/lfglabs-dev/utu_bridge_indexer.git#main
+      dockerfile: Dockerfile
+    depends_on:
+      - etcd
+    restart: unless-stopped
+    ports:
+      - "8081:8081"
+    volumes:
+      - type: bind
+        source: ./.env
+        target: /data/env
+    environment:
+      PERSIST_TO_ETCD: http://etcd:2379
+      SINK_ID: utu_bridge_indexer
+      AUTH_TOKEN: dna_kYXQudNzRv0klWcPzd13
+
 volumes:
+  etcd_data:
   nginx_secrets:
 
 networks:


### PR DESCRIPTION
This closes https://github.com/lfglabs-dev/api.utu.lfg.rs/issues/3#issue-2651019006

It manages:
- a bitcoin core node
- an ordinal node
- a nginx reverse proxy automatically generating (and renewing) TLS certificates
- the UTU runes bridge backend (api.lfg.utu.rs)
- the auto-claim service for UTU
- an ETCD instance for starknet indexer data persistence
- the bridge indexer

The nginx reverse proxy specifically provides these services:
### **btcrpc.lfg.rs (HTTPS):**
- Serves a welcome page with service information
- Proxies RPC requests to the Bitcoin Core node
### **ord.lfg.rs (HTTPS):**
- Provides full access to the Ordinals explorer and API
### **api.utu.lfg.rs (HTTPS):**
- Provides secure access to the UTU backend API endpoints